### PR TITLE
[FEAT] CoinPay 1차 CRUD 구현 업비트 코인 가격 불러오기 포함

### DIFF
--- a/com.nameslowly.coinauctions.coinpay/build.gradle
+++ b/com.nameslowly.coinauctions.coinpay/build.gradle
@@ -28,12 +28,15 @@ ext {
 }
 
 dependencies {
+	implementation project(':com.nameslowly.coinauctions.common')
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+	runtimeOnly 'com.mysql:mysql-connector-j'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+	implementation 'org.springframework.boot:spring-boot-starter-amqp'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
@@ -47,3 +50,4 @@ dependencyManagement {
 tasks.named('test') {
 	useJUnitPlatform()
 }
+tasks.register("prepareKotlinBuildScriptModel"){}

--- a/com.nameslowly.coinauctions.coinpay/src/main/java/com/nameslowly/coinauctions/coinpay/CoinpayApplication.java
+++ b/com.nameslowly.coinauctions.coinpay/src/main/java/com/nameslowly/coinauctions/coinpay/CoinpayApplication.java
@@ -2,8 +2,12 @@ package com.nameslowly.coinauctions.coinpay;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
+@ComponentScan(basePackages = {"com.nameslowly.coinauctions.coinpay","com.nameslowly.coinauctions.common"})
 public class CoinpayApplication {
 
 	public static void main(String[] args) {

--- a/com.nameslowly.coinauctions.coinpay/src/main/java/com/nameslowly/coinauctions/coinpay/application/dto/request/CoinBidRequest.java
+++ b/com.nameslowly.coinauctions.coinpay/src/main/java/com/nameslowly/coinauctions/coinpay/application/dto/request/CoinBidRequest.java
@@ -1,0 +1,18 @@
+package com.nameslowly.coinauctions.coinpay.application.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Getter
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class CoinBidRequest {
+    private String username;
+    private Long coin_id;
+    private BigDecimal quantity;
+}

--- a/com.nameslowly.coinauctions.coinpay/src/main/java/com/nameslowly/coinauctions/coinpay/application/dto/request/CoinChargeRequest.java
+++ b/com.nameslowly.coinauctions.coinpay/src/main/java/com/nameslowly/coinauctions/coinpay/application/dto/request/CoinChargeRequest.java
@@ -1,0 +1,19 @@
+package com.nameslowly.coinauctions.coinpay.application.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Getter
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class CoinChargeRequest {
+    private BigDecimal charge_amount;
+    private String username;
+    private Long coin_id;
+}
+

--- a/com.nameslowly.coinauctions.coinpay/src/main/java/com/nameslowly/coinauctions/coinpay/application/dto/request/CoinCreateRequest.java
+++ b/com.nameslowly.coinauctions.coinpay/src/main/java/com/nameslowly/coinauctions/coinpay/application/dto/request/CoinCreateRequest.java
@@ -1,0 +1,16 @@
+package com.nameslowly.coinauctions.coinpay.application.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class CoinCreateRequest {
+    private String coin_real_name;
+    private String coin_name;
+}
+

--- a/com.nameslowly.coinauctions.coinpay/src/main/java/com/nameslowly/coinauctions/coinpay/application/dto/response/BidRefundMessage.java
+++ b/com.nameslowly.coinauctions.coinpay/src/main/java/com/nameslowly/coinauctions/coinpay/application/dto/response/BidRefundMessage.java
@@ -1,0 +1,17 @@
+package com.nameslowly.coinauctions.coinpay.application.dto.response;
+
+import java.math.BigDecimal;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class BidRefundMessage {
+    private String username;
+    private Long coin_id;
+    private BigDecimal Amount;
+}

--- a/com.nameslowly.coinauctions.coinpay/src/main/java/com/nameslowly/coinauctions/coinpay/application/dto/response/UpbitTickerResponse.java
+++ b/com.nameslowly.coinauctions.coinpay/src/main/java/com/nameslowly/coinauctions/coinpay/application/dto/response/UpbitTickerResponse.java
@@ -1,0 +1,20 @@
+package com.nameslowly.coinauctions.coinpay.application.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.math.BigDecimal;
+
+public class UpbitTickerResponse {
+    @JsonProperty("trade_price")
+    private BigDecimal tradePrice;
+
+    public BigDecimal getTradePrice() {
+        return tradePrice;
+    }
+
+    public void setTradePrice(BigDecimal tradePrice) {
+        this.tradePrice = tradePrice;
+    }
+}
+
+

--- a/com.nameslowly.coinauctions.coinpay/src/main/java/com/nameslowly/coinauctions/coinpay/application/service/CoinHistoryService.java
+++ b/com.nameslowly.coinauctions.coinpay/src/main/java/com/nameslowly/coinauctions/coinpay/application/service/CoinHistoryService.java
@@ -1,0 +1,32 @@
+package com.nameslowly.coinauctions.coinpay.application.service;
+
+import com.nameslowly.coinauctions.coinpay.domain.model.CoinHistory;
+import com.nameslowly.coinauctions.coinpay.domain.model.CoinHistoryVO;
+import com.nameslowly.coinauctions.coinpay.domain.repository.CoinHistoryRepository;
+import com.nameslowly.coinauctions.common.exception.GlobalException;
+import com.nameslowly.coinauctions.common.response.ResultCase;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CoinHistoryService {
+    private final CoinHistoryRepository coinHistoryRepository;
+
+    @Transactional(readOnly = true)
+    public List<CoinHistoryVO> getCoinHistory() {
+        List<CoinHistory> coinHistories = coinHistoryRepository.findAll();
+        if(coinHistories.isEmpty()) {
+            throw new GlobalException(ResultCase.NO_HISTORIES_FOUND);
+        }
+        return coinHistories.stream()
+            .map(CoinHistory::toCoinHistoryVO)
+            .collect(Collectors.toList());
+    }
+}

--- a/com.nameslowly.coinauctions.coinpay/src/main/java/com/nameslowly/coinauctions/coinpay/application/service/CoinPayListener.java
+++ b/com.nameslowly.coinauctions.coinpay/src/main/java/com/nameslowly/coinauctions/coinpay/application/service/CoinPayListener.java
@@ -1,0 +1,20 @@
+package com.nameslowly.coinauctions.coinpay.application.service;
+
+import com.nameslowly.coinauctions.coinpay.application.dto.response.BidRefundMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CoinPayListener {
+    private final CoinWalletService coinWalletService;
+
+    @RabbitListener(queues = "app.coin")
+    public void handleBidRefund(BidRefundMessage bidRefundMessage) {
+        // 메시지에 담긴 정보로 유저의 코인 복구
+        coinWalletService.restoreCoins(bidRefundMessage.getUsername(), bidRefundMessage.getCoin_id(), bidRefundMessage.getAmount());
+    }
+
+
+}

--- a/com.nameslowly.coinauctions.coinpay/src/main/java/com/nameslowly/coinauctions/coinpay/application/service/CoinService.java
+++ b/com.nameslowly.coinauctions.coinpay/src/main/java/com/nameslowly/coinauctions/coinpay/application/service/CoinService.java
@@ -1,0 +1,103 @@
+package com.nameslowly.coinauctions.coinpay.application.service;
+
+import com.nameslowly.coinauctions.coinpay.domain.model.Coin;
+import com.nameslowly.coinauctions.coinpay.domain.model.CoinVO;
+import com.nameslowly.coinauctions.coinpay.domain.repository.CoinRepository;
+import com.nameslowly.coinauctions.common.exception.GlobalException;
+import com.nameslowly.coinauctions.common.response.ResultCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CoinService {
+
+    private final CoinRepository coinRepository;
+    private final UpbitApiService upbitApiService;  // Upbit API 호출 서비스
+
+    @Transactional(readOnly = true) //모든 코인 조회
+    public List<CoinVO> getAllCoins(){
+        List<Coin> coins= coinRepository.findByIsDeletedFalse();
+        if (coins.isEmpty()) {
+            throw new GlobalException(ResultCase.NO_COINS_FOUND);  // 코인이 없을 경우
+        }
+        return coins.stream()
+                .map(Coin::toCoinVO)
+                .collect(Collectors.toList());
+    }
+
+    @Scheduled(fixedRate = 5000)  // 5초마다 실행 업비트에서 코인들 가격 갱신
+    public void updateCoinPrices() {
+        List<Coin> coins = coinRepository.findAll();
+        for (Coin coin : coins) {
+            try {
+                // Upbit API 호출하여 코인 가격 가져오기
+                BigDecimal price = upbitApiService.fetchCoinPrice(coin.getCoinRealName());
+                log.info("Updating price for coin: " + coin.getCoinRealName() + " with price: " + price);
+
+                // 코인 가격 업데이트
+                coin.coinUpdate(price.setScale(2, RoundingMode.HALF_UP));
+                coinRepository.save(coin);
+            } catch (Exception e) {
+                log.error("Error updating price for coin: " + coin.getCoinRealName(), e);
+                throw new GlobalException(ResultCase.COIN_PRICE_UPDATE_FAILED);  // 가격 업데이트 실패 시 예외 처리
+            }
+        }
+    }
+
+    // Upbit에서 코인 가격 가져오기
+    public BigDecimal getCoinPriceFromUpbit(String coinName) {
+        try {
+            return upbitApiService.fetchCoinPrice(coinName);
+        } catch (Exception e) {
+            log.error("Error fetching price from Upbit for coin: " + coinName, e);
+            throw new GlobalException(ResultCase.UPBIT_API_ERROR);  // Upbit API 호출 실패 시 예외 처리
+        } // Upbit API 호출 메서드
+    }
+    @Transactional //코인 등록
+    public CoinVO saveCoin(String coinName,String coinRealName, BigDecimal coinPrice) {
+        if (coinPrice == null || coinPrice.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new GlobalException(ResultCase.INVALID_COIN_PRICE);  // 유효하지 않은 코인 가격
+        }
+        Coin existingCoin = coinRepository.findByCoinName(coinName);
+        if (existingCoin != null) {
+            throw new GlobalException(ResultCase.COIN_ALREADY_EXISTS);  // 이미 존재하는 코인
+        }
+        Coin coin = Coin.builder()
+                .coinName(coinName)
+                .coinRealName(coinRealName)
+                .coinPrice(coinPrice.setScale(2, RoundingMode.HALF_UP))
+                .isDeleted(false)
+                .build();
+        coinRepository.save(coin);
+        return coin.toCoinVO();
+    }
+
+    @Transactional(readOnly = true) //코인아이디로 코인조회
+    public CoinVO getCoinById(Long coinId) {
+        Coin coin = coinRepository.findByIdAndIsDeletedFalse(coinId)
+                .orElseThrow(()->new GlobalException(ResultCase.COIN_NOT_FOUND));
+        if (coin.getCoinPrice() == null || coin.getCoinPrice().compareTo(BigDecimal.ZERO) <= 0) {
+            throw new GlobalException(ResultCase.INVALID_COIN_PRICE);  // 가격이 유효하지 않은 코인
+        }
+        return coin.toCoinVO();
+    }
+    @Transactional //코인 삭제 IsDeleted->true
+    public CoinVO deleteCoin(Long coinId) {
+        Coin coin = coinRepository.findById(coinId)
+                .orElseThrow(()->new GlobalException(ResultCase.COIN_NOT_FOUND));
+        coin.coinDelete();
+        coinRepository.save(coin);
+        return coin.toCoinVO();
+    }
+}

--- a/com.nameslowly.coinauctions.coinpay/src/main/java/com/nameslowly/coinauctions/coinpay/application/service/CoinWalletService.java
+++ b/com.nameslowly.coinauctions.coinpay/src/main/java/com/nameslowly/coinauctions/coinpay/application/service/CoinWalletService.java
@@ -1,0 +1,144 @@
+package com.nameslowly.coinauctions.coinpay.application.service;
+
+
+import com.nameslowly.coinauctions.coinpay.domain.model.Coin;
+import com.nameslowly.coinauctions.coinpay.domain.model.CoinHistory;
+import com.nameslowly.coinauctions.coinpay.domain.model.CoinWallet;
+import com.nameslowly.coinauctions.coinpay.domain.model.CoinWalletVO;
+import com.nameslowly.coinauctions.coinpay.application.dto.request.CoinBidRequest;
+import com.nameslowly.coinauctions.coinpay.application.dto.request.CoinChargeRequest;
+import com.nameslowly.coinauctions.coinpay.domain.repository.CoinHistoryRepository;
+import com.nameslowly.coinauctions.coinpay.domain.repository.CoinRepository;
+import com.nameslowly.coinauctions.coinpay.domain.repository.CoinWalletRepository;
+import com.nameslowly.coinauctions.common.exception.GlobalException;
+import com.nameslowly.coinauctions.common.response.ResultCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class CoinWalletService {
+
+    private final CoinRepository coinRepository;
+    private final CoinWalletRepository coinWalletRepository;
+    private final CoinHistoryRepository coinHistoryRepository;
+
+    @Transactional //코인 지갑 생성 -> 이미 해당유저와 코인이 있는경우 충전금액 만큼 코인 추가, 없을 경우 생성 -> 코인 히스토리 생성
+    public CoinWalletVO saveCoinWallet(CoinChargeRequest request) {
+        Coin coin = coinRepository.findByIdAndIsDeletedFalse(request.getCoin_id())
+            .orElseThrow(() -> new GlobalException(ResultCase.COIN_NOT_FOUND));
+
+        BigDecimal price = coin.getCoinPrice();
+
+        if (price == null || price.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new GlobalException(ResultCase.INVALID_COIN_PRICE);
+        }
+
+        BigDecimal chargeAmount = request.getCharge_amount();
+
+        if (chargeAmount == null || chargeAmount.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new GlobalException(ResultCase.INVALID_CHARGE_AMOUNT);
+        }
+        BigDecimal quantity = chargeAmount.divide(price, 2, RoundingMode.HALF_UP);
+
+        // username과 coinId로 기존 CoinWallet을 조회
+        CoinWallet coinWallet = coinWalletRepository.findByUsernameAndCoinId(request.getUsername(), request.getCoin_id())
+            .orElse(null);
+        log.info("Saving coin wallet: {}", coinWallet);
+        BigDecimal balanceBefore;
+        BigDecimal balanceAfter;
+
+        if (coinWallet != null) {
+            // 이미 코인 월렛이 존재하는 경우 수량만 업데이트
+            balanceBefore = coinWallet.getQuantity();
+            balanceAfter = balanceBefore.add(quantity);
+            coinWallet.coinWalletUpdate(balanceAfter);  // 기존 수량에 더함
+        } else {
+            // 새로운 CoinWallet을 생성
+            balanceBefore = BigDecimal.ZERO;
+            balanceAfter = quantity;
+            coinWallet = CoinWallet.builder()
+                .username(request.getUsername())
+                .coinId(request.getCoin_id())
+                .quantity(quantity)
+                .build();
+        }
+
+        coinWalletRepository.save(coinWallet);
+
+        // CoinHistory 저장
+        CoinHistory coinHistory = CoinHistory.builder()
+            .username(request.getUsername())
+            .coinId(request.getCoin_id())
+            .amount(quantity)
+            .balanceBefore(balanceBefore)
+            .balanceAfter(balanceAfter)
+            .reason("코인 충전")
+            .build();
+        coinHistoryRepository.save(coinHistory);
+
+        return coinWallet.toCoinWalletVO();
+    }
+
+    @Transactional //코인 바인딩 feign요청 들어왔을 때 입찰한 만큼의 코인 바인딩 후 코인 히스토리로 남김
+    public void changeBidCoin(CoinBidRequest request) {
+        CoinWallet coinWallet = coinWalletRepository.findByUsernameAndCoinId(request.getUsername(),
+            request.getCoin_id())
+            .orElseThrow(() -> new GlobalException(ResultCase.COIN_WALLET_NOT_FOUND));
+        if (coinWallet == null) {
+            throw new GlobalException(ResultCase.COIN_WALLET_NOT_FOUND);
+        }
+        BigDecimal balanceBefore = coinWallet.getQuantity();
+        BigDecimal updatedQuantity = balanceBefore.add(request.getQuantity());
+        if (updatedQuantity.compareTo(BigDecimal.ZERO) < 0) {
+            throw new GlobalException(ResultCase.INVALID_QUANTITY);
+        }
+        coinWallet.coinWalletUpdate(updatedQuantity);
+        coinWalletRepository.save(coinWallet);
+        CoinHistory coinHistory = CoinHistory.builder()
+            .username(request.getUsername())
+            .coinId(request.getCoin_id())
+            .amount(request.getQuantity())
+            .balanceBefore(balanceBefore)
+            .balanceAfter(updatedQuantity)
+            .reason("코인 바인딩")
+            .build();
+        coinHistoryRepository.save(coinHistory);
+    }
+
+    @Transactional(readOnly = true) //유저의 로그인 ID에 해당하는 코인지갑 확인
+    public List<CoinWalletVO> getCoinWallet(String username) {
+        List<CoinWallet> coinWallet = coinWalletRepository.findByUsername(username);
+        return coinWallet.stream()
+            .map(CoinWallet::toCoinWalletVO)
+            .collect(Collectors.toList());
+    }
+
+    @Transactional //메시징 시스템을 통해 새로운 입찰이 나타났을때 기존 입찰에 대한 코인 회복 -> 코인 히스토리 생성
+    public void restoreCoins(String username, Long coinId, BigDecimal amount) {
+        CoinWallet wallet = coinWalletRepository.findByUsernameAndCoinId(username, coinId)
+            .orElseThrow(() -> new GlobalException(ResultCase.COIN_WALLET_NOT_FOUND));
+        BigDecimal balanceBefore = wallet.getQuantity(); // 변경 전 잔액
+        BigDecimal balanceAfter = balanceBefore.add(amount); // 변경 후 잔액
+        wallet.coinWalletUpdate(balanceAfter);
+        coinWalletRepository.save(wallet);
+        CoinHistory coinHistory = CoinHistory.builder()
+            .username(username)
+            .coinId(coinId)
+            .amount(amount)
+            .balanceBefore(balanceBefore)
+            .balanceAfter(balanceAfter)
+            .reason("기존 입찰 코인 회복")
+            .build();
+        coinHistoryRepository.save(coinHistory);
+    }
+}

--- a/com.nameslowly.coinauctions.coinpay/src/main/java/com/nameslowly/coinauctions/coinpay/application/service/UpbitApiService.java
+++ b/com.nameslowly.coinauctions.coinpay/src/main/java/com/nameslowly/coinauctions/coinpay/application/service/UpbitApiService.java
@@ -1,0 +1,45 @@
+package com.nameslowly.coinauctions.coinpay.application.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nameslowly.coinauctions.coinpay.application.dto.response.UpbitTickerResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+import java.math.BigDecimal;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UpbitApiService {
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper jacksonObjectMapper;
+
+    public BigDecimal fetchCoinPrice(String coinRealName) {
+        // Upbit API URL 설정
+        String url = "https://api.upbit.com/v1/ticker?markets=" + coinRealName;
+        log.info("Fetching upbit ticker from " + url);
+        try {
+            // API 호출 (응답을 배열로 받음)
+            ResponseEntity<UpbitTickerResponse[]> response = restTemplate.getForEntity(url, UpbitTickerResponse[].class);
+            UpbitTickerResponse[] tickerData = response.getBody();
+            if (tickerData != null) {
+                String jsonString = jacksonObjectMapper.writeValueAsString(tickerData);
+                log.info("Upbit ticker data: " + jsonString);
+            }
+            // 첫 번째 객체의 trade_price (실시간 가격) 반환
+            if (tickerData != null && tickerData.length > 0) {
+                return tickerData[0].getTradePrice();
+            } else {
+                throw new RuntimeException("No data returned from Upbit API.");
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Error fetching coin price from Upbit: " + e.getMessage());
+        }
+    }
+}

--- a/com.nameslowly.coinauctions.coinpay/src/main/java/com/nameslowly/coinauctions/coinpay/config/RestTemplateConfig.java
+++ b/com.nameslowly.coinauctions.coinpay/src/main/java/com/nameslowly/coinauctions/coinpay/config/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package com.nameslowly.coinauctions.coinpay.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/com.nameslowly.coinauctions.coinpay/src/main/java/com/nameslowly/coinauctions/coinpay/domain/model/Coin.java
+++ b/com.nameslowly.coinauctions.coinpay/src/main/java/com/nameslowly/coinauctions/coinpay/domain/model/Coin.java
@@ -1,0 +1,49 @@
+package com.nameslowly.coinauctions.coinpay.domain.model;
+
+import com.nameslowly.coinauctions.common.shared.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Entity
+@Getter
+@ToString
+@Builder
+@Table(name = "p_coins")
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Coin extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="coin_id")
+    private Long id;
+
+    @Column(name = "coin_name", nullable = false, unique = true)
+    private String coinName;
+    @Column(name = "coin_real_name", nullable = false, unique = true)
+    private String coinRealName;
+    @Column(precision = 10, scale = 2, name = "coin_price", nullable = false, unique = true)
+    private BigDecimal coinPrice;
+    @Column(name = "is_deleted")
+    private Boolean isDeleted = false;
+
+    // Getters and Setters
+    @Builder
+    public Coin(String coinName, String coinRealName, BigDecimal coinPrice) {
+        this.coinName = coinName;
+        this.coinRealName = coinRealName;
+        this.coinPrice = coinPrice;
+        this.isDeleted = false;
+    }
+    public void coinUpdate(BigDecimal price){
+        this.coinPrice = price;
+    }
+    public void coinDelete(){
+        this.isDeleted = true;
+    }
+    public CoinVO toCoinVO() {
+        return new CoinVO(id, coinName, coinRealName, coinPrice);
+    }
+}

--- a/com.nameslowly.coinauctions.coinpay/src/main/java/com/nameslowly/coinauctions/coinpay/domain/model/CoinHistory.java
+++ b/com.nameslowly.coinauctions.coinpay/src/main/java/com/nameslowly/coinauctions/coinpay/domain/model/CoinHistory.java
@@ -1,0 +1,52 @@
+package com.nameslowly.coinauctions.coinpay.domain.model;
+
+import com.nameslowly.coinauctions.common.shared.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@Getter
+@ToString
+@Builder
+@Table(name = "p_coin_histories")
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CoinHistory extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="coin_history_id")
+    private Long id;
+    private String username;
+    private Long coinId;
+    @Column(precision = 12, scale = 2, nullable = false)
+    private BigDecimal amount;
+    @Column(name = "balance_before")
+    private BigDecimal balanceBefore;
+    @Column(name = "balance_after")
+    private BigDecimal balanceAfter;
+    private String reason; //EX)코인 충전, 코인 바인딩, 새로운 입찰로 인한 코인 회복 Enum으로 다루는게 나을라나?
+
+    @Builder
+    public CoinHistory(String username, Long coinId, BigDecimal amount, BigDecimal balanceBefore, BigDecimal balanceAfter, String reason) {
+        this.username = username;
+        this.coinId = coinId;
+        this.amount = amount;
+        this.balanceBefore = balanceBefore;
+        this.balanceAfter = balanceAfter;
+        this.reason = reason;
+    }
+    public CoinHistoryVO toCoinHistoryVO() {return new CoinHistoryVO(id, username, coinId, amount, balanceBefore, balanceAfter, reason);}
+}
+

--- a/com.nameslowly.coinauctions.coinpay/src/main/java/com/nameslowly/coinauctions/coinpay/domain/model/CoinHistoryVO.java
+++ b/com.nameslowly.coinauctions.coinpay/src/main/java/com/nameslowly/coinauctions/coinpay/domain/model/CoinHistoryVO.java
@@ -1,0 +1,21 @@
+package com.nameslowly.coinauctions.coinpay.domain.model;
+
+import java.math.BigDecimal;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@AllArgsConstructor
+@Getter
+@ToString
+@EqualsAndHashCode
+public class CoinHistoryVO {
+    private Long id;
+    private String username;
+    private Long coin_id;
+    private BigDecimal amount;
+    private BigDecimal balanceBefore;
+    private BigDecimal balanceAfter;
+    private String reason;
+}

--- a/com.nameslowly.coinauctions.coinpay/src/main/java/com/nameslowly/coinauctions/coinpay/domain/model/CoinVO.java
+++ b/com.nameslowly.coinauctions.coinpay/src/main/java/com/nameslowly/coinauctions/coinpay/domain/model/CoinVO.java
@@ -1,0 +1,20 @@
+package com.nameslowly.coinauctions.coinpay.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+
+@AllArgsConstructor
+@Getter
+@ToString
+@EqualsAndHashCode
+public class CoinVO implements Serializable {
+    private Long id;
+    private String coin_name;
+    private String coin_real_name;
+    private BigDecimal coin_price;
+}

--- a/com.nameslowly.coinauctions.coinpay/src/main/java/com/nameslowly/coinauctions/coinpay/domain/model/CoinWallet.java
+++ b/com.nameslowly.coinauctions.coinpay/src/main/java/com/nameslowly/coinauctions/coinpay/domain/model/CoinWallet.java
@@ -1,0 +1,34 @@
+package com.nameslowly.coinauctions.coinpay.domain.model;
+
+import com.nameslowly.coinauctions.common.shared.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Entity
+@Getter
+@ToString
+@Builder
+@Table(name = "p_coin_wallets")
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CoinWallet extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="coin_wallet_id")
+    private Long id;
+    @Column(unique = true, nullable = false)
+    private String username;
+    @Column(name="coin_id", nullable = false)
+    private Long coinId;
+    @Column(precision = 12, scale = 2, nullable = false)
+    private BigDecimal quantity;
+
+    public CoinWalletVO toCoinWalletVO() {
+        return new CoinWalletVO(id, username, coinId, quantity);
+    }
+    public void coinWalletUpdate(BigDecimal quantity) {
+        this.quantity = quantity;
+    }
+}

--- a/com.nameslowly.coinauctions.coinpay/src/main/java/com/nameslowly/coinauctions/coinpay/domain/model/CoinWalletVO.java
+++ b/com.nameslowly.coinauctions.coinpay/src/main/java/com/nameslowly/coinauctions/coinpay/domain/model/CoinWalletVO.java
@@ -1,0 +1,19 @@
+package com.nameslowly.coinauctions.coinpay.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.math.BigDecimal;
+
+@AllArgsConstructor
+@Getter
+@ToString
+@EqualsAndHashCode
+public class CoinWalletVO {
+    private Long id;
+    private String username;
+    private Long coin_id;
+    private BigDecimal quantity;
+}

--- a/com.nameslowly.coinauctions.coinpay/src/main/java/com/nameslowly/coinauctions/coinpay/domain/repository/CoinHistoryRepository.java
+++ b/com.nameslowly.coinauctions.coinpay/src/main/java/com/nameslowly/coinauctions/coinpay/domain/repository/CoinHistoryRepository.java
@@ -1,0 +1,10 @@
+package com.nameslowly.coinauctions.coinpay.domain.repository;
+
+import com.nameslowly.coinauctions.coinpay.domain.model.CoinHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CoinHistoryRepository extends JpaRepository<CoinHistory, Long> {
+
+}

--- a/com.nameslowly.coinauctions.coinpay/src/main/java/com/nameslowly/coinauctions/coinpay/domain/repository/CoinRepository.java
+++ b/com.nameslowly.coinauctions.coinpay/src/main/java/com/nameslowly/coinauctions/coinpay/domain/repository/CoinRepository.java
@@ -1,0 +1,17 @@
+package com.nameslowly.coinauctions.coinpay.domain.repository;
+
+import com.nameslowly.coinauctions.coinpay.domain.model.Coin;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface CoinRepository extends JpaRepository<Coin, Long> {
+    Optional<Coin> findByIdAndIsDeletedFalse(Long coinId);
+
+    Coin findByCoinName(String coinName);
+
+    List<Coin> findByIsDeletedFalse();
+}

--- a/com.nameslowly.coinauctions.coinpay/src/main/java/com/nameslowly/coinauctions/coinpay/domain/repository/CoinWalletRepository.java
+++ b/com.nameslowly.coinauctions.coinpay/src/main/java/com/nameslowly/coinauctions/coinpay/domain/repository/CoinWalletRepository.java
@@ -1,0 +1,15 @@
+package com.nameslowly.coinauctions.coinpay.domain.repository;
+
+import com.nameslowly.coinauctions.coinpay.domain.model.CoinWallet;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CoinWalletRepository extends JpaRepository<CoinWallet, Long> {
+    Optional<CoinWallet> findByUsernameAndCoinId(String username, Long coinId);
+
+    List<CoinWallet> findByUsername(String username);
+}

--- a/com.nameslowly.coinauctions.coinpay/src/main/java/com/nameslowly/coinauctions/coinpay/presentation/controller/CoinController.java
+++ b/com.nameslowly.coinauctions.coinpay/src/main/java/com/nameslowly/coinauctions/coinpay/presentation/controller/CoinController.java
@@ -1,0 +1,43 @@
+package com.nameslowly.coinauctions.coinpay.presentation.controller;
+
+import com.nameslowly.coinauctions.coinpay.domain.model.CoinVO;
+import com.nameslowly.coinauctions.coinpay.application.dto.request.CoinCreateRequest;
+import com.nameslowly.coinauctions.coinpay.application.service.CoinService;
+import com.nameslowly.coinauctions.common.response.CommonResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.math.BigDecimal;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/coins")
+public class CoinController {
+
+    private final CoinService coinService;
+
+    @PostMapping("/create")
+    public CommonResponse createCoin(@RequestBody CoinCreateRequest coinRequest) {
+        // Upbit API에서 코인 가격 가져오기
+        BigDecimal coinPrice = coinService.getCoinPriceFromUpbit(coinRequest.getCoin_real_name());
+        // 코인 정보 저장
+        CoinVO coin = coinService.saveCoin(coinRequest.getCoin_name(),coinRequest.getCoin_real_name(), coinPrice);
+        return CommonResponse.success(coin);
+    }
+
+    @GetMapping
+    public CommonResponse getAllCoins() {
+        return CommonResponse.success(coinService.getAllCoins());
+    }
+
+    @DeleteMapping("/{coinId}")
+    public CommonResponse deleteCoin(@PathVariable Long coinId){
+        CoinVO coin = coinService.deleteCoin(coinId);
+        return CommonResponse.success(coin);
+    }
+    @GetMapping("/auctions/{coinId}")
+    public CoinVO getCoinById(@PathVariable("coinId") Long coinId) {
+        return coinService.getCoinById(coinId);
+    }
+
+}

--- a/com.nameslowly.coinauctions.coinpay/src/main/java/com/nameslowly/coinauctions/coinpay/presentation/controller/CoinHistoryController.java
+++ b/com.nameslowly.coinauctions.coinpay/src/main/java/com/nameslowly/coinauctions/coinpay/presentation/controller/CoinHistoryController.java
@@ -1,0 +1,25 @@
+package com.nameslowly.coinauctions.coinpay.presentation.controller;
+
+import com.nameslowly.coinauctions.coinpay.application.service.CoinHistoryService;
+import com.nameslowly.coinauctions.coinpay.domain.model.CoinHistory;
+import com.nameslowly.coinauctions.coinpay.domain.model.CoinHistoryVO;
+import com.nameslowly.coinauctions.coinpay.domain.repository.CoinHistoryRepository;
+import com.nameslowly.coinauctions.common.response.CommonResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/coin_histories/")
+public class CoinHistoryController {
+
+    private final CoinHistoryService coinHistoryService;
+
+    @GetMapping
+    public CommonResponse getCoinHistory() {
+        return CommonResponse.success(coinHistoryService.getCoinHistory());
+    }
+}

--- a/com.nameslowly.coinauctions.coinpay/src/main/java/com/nameslowly/coinauctions/coinpay/presentation/controller/CoinWalletController.java
+++ b/com.nameslowly.coinauctions.coinpay/src/main/java/com/nameslowly/coinauctions/coinpay/presentation/controller/CoinWalletController.java
@@ -1,0 +1,34 @@
+package com.nameslowly.coinauctions.coinpay.presentation.controller;
+
+import com.nameslowly.coinauctions.coinpay.domain.model.CoinWalletVO;
+import com.nameslowly.coinauctions.coinpay.application.dto.request.CoinBidRequest;
+import com.nameslowly.coinauctions.coinpay.application.dto.request.CoinChargeRequest;
+import com.nameslowly.coinauctions.coinpay.application.service.CoinWalletService;
+import com.nameslowly.coinauctions.common.response.CommonResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/coin_wallets")
+public class CoinWalletController {
+    private final CoinWalletService coinWalletService;
+
+    @PostMapping
+    public CommonResponse chargeCoin(@RequestBody CoinChargeRequest request){
+        CoinWalletVO coinWallet = coinWalletService.saveCoinWallet(request);
+        return CommonResponse.success(coinWallet);
+    }
+    @PutMapping("/bids") //해당 api는 feign요청이므로 일단은 CommonResponse를 따로 통일 안함 테스트 우선
+    public void changeBidCoin(@RequestBody CoinBidRequest request){
+        coinWalletService.changeBidCoin(request);
+    }
+    @GetMapping("/{username}")
+    public CommonResponse getCoinWallet(@PathVariable String username){
+        List<CoinWalletVO> coinWallet = coinWalletService.getCoinWallet(username);
+        return CommonResponse.success(coinWallet);
+    }
+
+}

--- a/com.nameslowly.coinauctions.coinpay/src/main/resources/application.properties
+++ b/com.nameslowly.coinauctions.coinpay/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=coinpay

--- a/com.nameslowly.coinauctions.coinpay/src/main/resources/application.yml
+++ b/com.nameslowly.coinauctions.coinpay/src/main/resources/application.yml
@@ -1,0 +1,41 @@
+spring:
+  application:
+    name: coin
+  rabbitmq:
+    host: localhost
+    port: 5672
+    username: guest
+    password: guest
+
+#message:
+#  queue:
+#    coinpay: app.coin
+
+
+  datasource:
+    url: jdbc:mysql://localhost:3306/coin  # 여기에 실제 데이터베이스 이름을 넣으세요
+    username: root
+    password:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update  # 테이블 자동 생성/업데이트 (운영 환경에 맞게 설정)
+    show-sql: true     # SQL 쿼리 로그 확인
+    database-platform: org.hibernate.dialect.MySQL8Dialect
+
+  # Hibernate 기본 설정
+  hibernate:
+    naming:
+      physical-strategy: org.springframework.boot.orm.jpa.hibernate.SpringPhysicalNamingStrategy
+      implicit-strategy: org.springframework.boot.orm.jpa.hibernate.SpringImplicitNamingStrategy
+
+# 서버 기본 설정 (필요한 경우)
+server:
+  port: 8084
+
+
+
+
+
+

--- a/com.nameslowly.coinauctions.common/src/main/java/com/nameslowly/coinauctions/common/response/ResultCase.java
+++ b/com.nameslowly.coinauctions.common/src/main/java/com/nameslowly/coinauctions/common/response/ResultCase.java
@@ -36,7 +36,16 @@ public enum ResultCase {
     EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, 2005, "만료된 Refresh Token"),
 
     /* 서비스별로 분기 */
-
+    COIN_NOT_FOUND(HttpStatus.NOT_FOUND, 7000, "코인을 찾을 수 없습니다."),
+    COIN_WALLET_NOT_FOUND(HttpStatus.NOT_FOUND, 7001, "해당 코인과 유저에 해당하는 코인지갑을 찾을 수 없습니다."),
+    INVALID_COIN_PRICE(HttpStatus.BAD_REQUEST, 7002, "해당 코인의 값이 유효하지 않습니다."),
+    INVALID_CHARGE_AMOUNT(HttpStatus.BAD_REQUEST, 7003, "해당 충전금액이 유효하지 않습니다."),
+    INVALID_QUANTITY(HttpStatus.BAD_REQUEST, 7004, "코인 수량이 유효하지 않습니다."),
+    NO_COINS_FOUND(HttpStatus.NOT_FOUND, 7005, "코인이 존재하지 않습니다."),
+    COIN_PRICE_UPDATE_FAILED(HttpStatus.BAD_REQUEST, 7006, "코인 가격 업데이트에 실패했습니다"),
+    UPBIT_API_ERROR(HttpStatus.BAD_REQUEST, 7007, "업비트 API를 불러오는데 실패했습니다."),
+    COIN_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, 7008, "해당 코인은 이미 존재합니다."),
+    NO_HISTORIES_FOUND(HttpStatus.NOT_FOUND, 7009, "코인 히스토리가 존재하지 않습니다."),
     /* 경로 8000번대 */
     ROUTE_NOT_INVALID(HttpStatus.BAD_REQUEST, 8000, "그런 경로 없습니다.");
 


### PR DESCRIPTION
## 개요
CoinPay 1차 CRUD 구현 업비트 코인 가격 불러오기 포함
feign요청과 메시징 받았을때 작업도 일단은 해놨습니다.
당장은 username을 request로 바꿔서 테스트 해봤고 이후 머지하고 헤더에서 유저네임 받아올 예정입니다.
Bulk 업데이트를 통해 가격 변동이 있는 코인들만 모아서 한번에 update 여러 요청을 보내던걸 한번에 해서 성능을 개선
현재 고민사항 : 1안) 유저를 생성하면 현재 있는 모든 코인에 대한 유저지갑을 만들어준다. 
EX) coin1,2,3,4가 있을때 유저가 생성되면 일단은 개수 0개로 coinWallet을 생성
2안) 유저가 코인을 구매하면 그때 생성한다. 일단은 이 방법으로 구현해놨습니다.
1안 
장점: 코인을 충전할때 코인 지갑의 여부를 항상 체크하지 않아도됨
단점: 실제로 충전하지 않아도 데이터베이스를 만들기 때문에 불필요한 데이터가 늘어날 수 있음
2안
장점: 불필요한 데이터 방지, 새로운 코인이 생성 될 때 유연한 대처가능
단점: 코인 충전 시마다 지갑이 있는지 체크하고 없으면 새로 생성해야 하므로 추가 로직이 필요합니다. (당장은 구현해서 상관X)
        첫 충전 때마다 지갑 생성에 대한 로직이 매번 실행되므로 성능에 약간의 오버헤드가 발생할 수 있습니다.
## 작업사항
- 내용을 적어주세요.
CoinPay에 해당하는 MVP 작성
## 관련 이슈
- 