### PR TITLE
feat : 회원가입,로그인도 게이트웨이에서 라우팅 되도록 수정 + userRole 소소한 수정

### DIFF
--- a/com.nameslowly.coinauctions.auth/src/main/java/com/nameslowly/coinauctions/auth/domain/model/User.java
+++ b/com.nameslowly.coinauctions.auth/src/main/java/com/nameslowly/coinauctions/auth/domain/model/User.java
@@ -38,7 +38,7 @@ public class User extends BaseEntity {
     private UserRole role;
 
     @Column(name = "is_public")
-    private boolean isPublic = true;
+    private Boolean isPublic = true;
 
     // 유저 생성 메서드
     public static User create(String username, String password, UserRole role

--- a/com.nameslowly.coinauctions.auth/src/main/java/com/nameslowly/coinauctions/auth/infrastructure/security/WebSecurityConfig.java
+++ b/com.nameslowly.coinauctions.auth/src/main/java/com/nameslowly/coinauctions/auth/infrastructure/security/WebSecurityConfig.java
@@ -105,13 +105,13 @@ public class WebSecurityConfig {
     private void settingRequestAuthorization(HttpSecurity http) throws Exception {
         http.authorizeHttpRequests(authz ->
                 authz
-                        // 정적 파일
+                        // 정적 파일 드루와
                         .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
-                        // Swagger UI
+                        // Swagger UI 드루와
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
-                        // auth api
+                        // 유저 컨트롤러 쓸거면 드루와
                         .requestMatchers("/api/auth/**").permitAll()
-                        // auth-filter api
+                        // 로그인할거면 드루와
                         .requestMatchers("/user/login").permitAll()
                         // 그 외
                         .anyRequest().authenticated() // TODO : 인증 구현 후 authenticated()로 변경

--- a/com.nameslowly.coinauctions.common/src/main/java/com/nameslowly/coinauctions/common/shared/UserRole.java
+++ b/com.nameslowly.coinauctions.common/src/main/java/com/nameslowly/coinauctions/common/shared/UserRole.java
@@ -10,7 +10,7 @@ public enum UserRole {
 
     MASTER("ROLE_MASTER"), // 마스터
     COMPANY("ROLE_USER"), // 경매 등록, 경매 입찰
-    HUBMANAGER("ROLE_GUEST"); // 구경
+    GUEST("ROLE_GUEST"); // 구경
 
     private final String authority;
 

--- a/com.nameslowly.coinauctions.common/src/main/java/com/nameslowly/coinauctions/common/shared/UserRole.java
+++ b/com.nameslowly.coinauctions.common/src/main/java/com/nameslowly/coinauctions/common/shared/UserRole.java
@@ -9,7 +9,7 @@ import lombok.RequiredArgsConstructor;
 public enum UserRole {
 
     MASTER("ROLE_MASTER"), // 마스터
-    COMPANY("ROLE_USER"), // 경매 등록, 경매 입찰
+    USER("ROLE_USER"), // 경매 등록, 경매 입찰
     GUEST("ROLE_GUEST"); // 구경
 
     private final String authority;

--- a/com.nameslowly.coinauctions.gateway/src/main/java/com/nameslowly/coinauctions/gateway/config/GatewayConfig.java
+++ b/com.nameslowly.coinauctions.gateway/src/main/java/com/nameslowly/coinauctions/gateway/config/GatewayConfig.java
@@ -16,6 +16,10 @@ public class GatewayConfig {
     public RouteLocator customRoutes(RouteLocatorBuilder builder, JwtAuthGatewayFilter authFilter) {
 
         return builder.routes()
+            // login 시에는 인가(jwt토큰으로 인가) 없이 바로 라우팅
+            .route("userauth-service", r -> r.path("/user/login")
+                .uri("lb://userauth-service")
+            )
             // userAuth
             .route("userauth-service", r -> r.path("/api/auth/**")
                 .filters(f -> f.filter(authFilter))

--- a/com.nameslowly.coinauctions.gateway/src/main/java/com/nameslowly/coinauctions/gateway/config/GatewayConfig.java
+++ b/com.nameslowly.coinauctions.gateway/src/main/java/com/nameslowly/coinauctions/gateway/config/GatewayConfig.java
@@ -20,6 +20,10 @@ public class GatewayConfig {
             .route("userauth-service", r -> r.path("/user/login")
                 .uri("lb://userauth-service")
             )
+            // 회원가입 시에도 인가(jwt토큰으로 인가) 없이 바로 라우팅 - 구체적인 경로로 우선적으로 처리된다
+            .route("userauth-service", r -> r.path("/api/auth/sign-up")
+                .uri("lb://userauth-service")
+            )
             // userAuth
             .route("userauth-service", r -> r.path("/api/auth/**")
                 .filters(f -> f.filter(authFilter))


### PR DESCRIPTION
## 개요
- 판준님 요청사항 반영

## 작업사항
- [회원가입] 인가 과정을 생략해서 토큰없이 바로 게이트웨이 통해 auth 서버로 라우팅되어 회원가입하도록함
- [로그인] 게이트웨이 라우팅에 포함시키고, 역시 인가과정 생략하여 게이트웨이 통해서도 회원가입 url 로 바로 들어가도록함 (auth 서버의 필터에서 처리됨)
- userRole 에서 guest 로 수정함

## 관련 이슈 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced routing configurations allow unauthenticated access to user login and sign-up endpoints.
	- Improved comments in security configurations for better clarity on request matchers.

- **Changes**
	- Renamed user role from `HUBMANAGER` to `GUEST` to better reflect role semantics.
	- Updated user model to allow null values for the `isPublic` field, enhancing flexibility in user data handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->