### PR TITLE
chore : 유레카서버 컨테이너 이름 수정

### DIFF
--- a/app-compose.yml
+++ b/app-compose.yml
@@ -4,7 +4,7 @@ services:
   eureka-server:
     networks:
       - auction-network
-    container_name: eureka-server # 만들 컨테이너 이름 (이겠지)
+    container_name: eureka-service # 만들 컨테이너 이름 (이겠지)
     build: # 새 이미지를 직접 만들어씀
       context: . # app-compose.yml 이 있는 경로
       dockerfile: ./com.nameslowly.coinauctions.server/Dockerfile # 빌드할 이미지이름


### PR DESCRIPTION
## 개요
- 유레카 서버 컨테이너 이름 수정

## 작업사항
- 유레카 서버의 spring.application.name = eureka-service, 
app-compose.yml 에서 유레카 서버의 컨테이너 이름은 eureka-server 로 등록된 상황에서,

다른 유레카 클라이언트 서버들이 eureka-service 이름을 가진 서버에 등록하고 있어 디스커버리 오류 발생한 것으로 판단,
유레카 서버 컨테이너이름을 이에 맞게 수정

## 관련 이슈